### PR TITLE
Fixed R8 minification issues with Gson serialization

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,7 @@
 
 - **⚠️ BREAKING**: `VerificationStateOtpData` now carries only `remainingAttempts`.
 - `ConfigurationResponseData` now includes optional `otpResendPeriodSeconds` (`null` on older backends that do not provide the field yet).
+- Fixed R8 minification ([#76](https://github.com/wultra/digital-onboarding-android/issues/76)).
 
 ## 2.0.0 (Apr, 2026)
 

--- a/library/src/main/java/com/wultra/android/digitalonboarding/CustomerVerificationScanProcess.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/CustomerVerificationScanProcess.kt
@@ -19,6 +19,7 @@
 package com.wultra.android.digitalonboarding
 
 import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
 import com.wultra.android.digitalonboarding.networking.model.Document
 import com.wultra.android.digitalonboarding.networking.model.DocumentFileSide
 
@@ -77,27 +78,27 @@ class VerificationScanProcess {
     }
 
     private data class CacheV2(
-        val v: Int,
-        val documents: List<CachedDocument>,
+        @SerializedName("v") val v: Int,
+        @SerializedName("documents") val documents: List<CachedDocument>,
     ) {
         data class CachedDocument(
-            val type: String,
-            val sides: List<CachedSide>,
+            @SerializedName("type") val type: String,
+            @SerializedName("sides") val sides: List<CachedSide>,
         )
 
         data class CachedSide(
-            val side: Side,
-            val serverId: String,
-            val uploadState: UploadState,
+            @SerializedName("side") val side: Side,
+            @SerializedName("serverId") val serverId: String,
+            @SerializedName("uploadState") val uploadState: UploadState,
         ) {
             enum class Side {
-                FRONT,
-                BACK,
+                @SerializedName("FRONT") FRONT,
+                @SerializedName("BACK") BACK,
             }
 
             enum class UploadState {
-                ACCEPTED,
-                REJECTED,
+                @SerializedName("ACCEPTED") ACCEPTED,
+                @SerializedName("REJECTED") REJECTED,
             }
         }
     }

--- a/library/src/main/java/com/wultra/android/digitalonboarding/DemoEndpoints.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/DemoEndpoints.kt
@@ -17,6 +17,7 @@
 package com.wultra.android.digitalonboarding
 
 import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
 import com.wultra.android.digitalonboarding.log.WDOLogger
 import com.wultra.android.digitalonboarding.networking.model.OTPDetailRequest
 import com.wultra.android.digitalonboarding.networking.model.OTPDetailRequestData
@@ -231,7 +232,7 @@ internal class OtpEndpointNetworking {
         }
 
         private data class OtpCodeResponse(
-            val otpCode: String?,
+            @SerializedName("otpCode") val otpCode: String?,
         )
 
         private fun escapeJson(value: String): String {


### PR DESCRIPTION
#76 
used @SerializedName to only protects what needs protecting, unlike blanket `-keep class ... { *; }` which disables all optimization for the entire class