### PR TITLE
Prepare 3.0.0 release metadata

### DIFF
--- a/.prepare-release.json
+++ b/.prepare-release.json
@@ -15,13 +15,13 @@
     },
     {
       "description": "SDK integration tutorial.",
-      "path": "docs/SDK-integration.md",
+      "path": "docs/SDK-Integration.md",
       "type": "version_replace",
       "match": "wultra-digital-onboarding:%VERSION%"
     },
     {
       "description": "SDK integration tutorial.",
-      "path": "docs/SDK-integration.md",
+      "path": "docs/SDK-Integration.md",
       "type": "versionstream_verify",
       "match": "`%VERSION_STREAM%`"
     },

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.0 (TBA)
+## 3.0.0 (Aug, 2026)
 
 - **⚠️ BREAKING**: `VerificationStateOtpData` now carries only `remainingAttempts`.
 - `ConfigurationResponseData` now includes optional `otpResendPeriodSeconds` (`null` on older backends that do not provide the field yet).

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -21,13 +21,14 @@ repositories {
 Then add a dependency
 
 ```kotlin
-implementation("com.wultra.android.digitalonboarding:wultra-digital-onboarding:1.3.0")
+implementation("com.wultra.android.digitalonboarding:wultra-digital-onboarding:3.0.0")
 ```
 
 ## Guaranteed PowerAuth Compatibility
 
-| WDO SDK           | PowerAuth SDK |  
+| WDO SDK           | PowerAuth SDK |
 |-------------------|---------------|
+| `3.0.x`           | `2.0.x`       |
 | `2.0.x`           | `1.9.x`       |
 | `1.3.x`           | `1.9.x`       |
 | `1.1.x` - `1.2.x` | `1.8.x`       |

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -21,7 +21,7 @@ repositories {
 Then add a dependency
 
 ```kotlin
-implementation("com.wultra.android.digitalonboarding:wultra-digital-onboarding:3.0.0")
+implementation("com.wultra.android.digitalonboarding:wultra-digital-onboarding:3.0.0-SNAPSHOT")
 ```
 
 ## Guaranteed PowerAuth Compatibility

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -14,6 +14,6 @@
 # and limitations under the License.
 #
 
-VERSION_NAME=1.3.0-SNAPSHOT
+VERSION_NAME=3.0.0
 GROUP_ID=com.wultra.android.digitalonboarding
 ARTIFACT_ID=wultra-digital-onboarding

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -14,6 +14,6 @@
 # and limitations under the License.
 #
 
-VERSION_NAME=3.0.0
+VERSION_NAME=3.0.0-SNAPSHOT
 GROUP_ID=com.wultra.android.digitalonboarding
 ARTIFACT_ID=wultra-digital-onboarding


### PR DESCRIPTION
This prepares the 3.0.0 SDK release metadata and docs so the branch is ready for release verification and publishing.

## What changed
- set `library/gradle.properties` `VERSION_NAME` to `3.0.0`
- updated `docs/Changelog.md` release heading from `3.0.0 (TBA)` to `3.0.0 (Aug, 2026)`
- updated `docs/SDK-Integration.md` dependency example to `3.0.0`
- added `3.0.x -> 2.0.x` row to the PowerAuth compatibility table
- fixed `.prepare-release.json` path from `docs/SDK-integration.md` to `docs/SDK-Integration.md` so release automation targets the correct file

## Notes
No code behavior changes; this PR updates release versioning and documentation only.