### PR TITLE
Fix document upload integration test flow

### DIFF
--- a/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTests.kt
+++ b/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTests.kt
@@ -203,15 +203,23 @@ class IntegrationTests {
                 return@runForAllEnvironments
             }
 
-            var statusResult = waitForNonProcessingStatus()
-            var state = statusResult.state
+            var state: VerificationStateData
+            for (document in documentsToScan) {
+                val uploadResult = helper.verification.awaitDocumentsSubmit(documentUploadFiles(document))
+                state = uploadResult.state
+                if (state.state == VerificationState.PROCESSING) {
+                    state = waitForNonProcessingStatus().state
+                }
+            }
 
             // Handle document re-scan when documents are rejected.
             if (state.state == VerificationState.SCAN_DOCUMENT) {
                 for (document in documentsToScan) {
-                    helper.verification.awaitDocumentsSubmit(documentUploadFiles(document))
-                    statusResult = waitForNonProcessingStatus()
-                    state = statusResult.state
+                    val uploadResult = helper.verification.awaitDocumentsSubmit(documentUploadFiles(document))
+                    state = uploadResult.state
+                    if (state.state == VerificationState.PROCESSING) {
+                        state = waitForNonProcessingStatus().state
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
The integration test was checking the post-upload verification state before submitting any document files, so the mocked backend never had a chance to advance beyond `SCAN_DOCUMENT`. This updates the flow to perform the uploads first and then wait for the backend to move to the next verification step.

## Changes
- upload each selected document before polling for a non-processing state
- keep waiting through `PROCESSING` after each upload
- preserve the re-scan path by re-uploading only when the backend explicitly remains in `SCAN_DOCUMENT`

## Notes
This is a targeted test-only fix in `IntegrationTests.kt` and keeps the expected backend progression aligned with mocked flows that continue to `OTP` or `ACTIVATION_FINISH`.