### PR TITLE
fix: add parameter validation and trap for proper cleanup in test.sh

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -89,11 +89,21 @@ while [[ $# -gt 0 ]]
 do
     case "$1" in
         -type)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: -type requires a value (unit or android)"
+                print_usage
+                exit 1
+            fi
             TYPE="$2"
             shift
             shift
             ;;
         -config)
+            if [ $# -lt 2 ]; then
+                echo "ERROR: -config requires a value (JSON content)"
+                print_usage
+                exit 1
+            fi
             CONFIG_JSON="$2"
             shift
             shift
@@ -116,6 +126,7 @@ if [ -z "${TYPE}" ]; then
     exit 1
 fi
 
+trap 'popd 2>/dev/null || true' EXIT
 pushd "${SCRIPT_FOLDER}/.."
 
 if [ -n "${CONFIG_JSON}" ]; then


### PR DESCRIPTION
## Summary

This PR fixes two robustness issues in the test.sh script that were identified during code review.

## Changes

**Parameter Validation**
- Added validation to ensure `-type` and `-config` parameters have values before accessing them
- Returns clear, actionable error messages when required parameters are missing values
- Prevents confusing "unbound variable" errors when users forget to provide parameter values

**Working Directory Cleanup**
- Added `trap 'popd 2>/dev/null || true' EXIT` to guarantee the directory stack is always popped
- Ensures working directory is restored even when the script exits with an error
- Improves local development experience and prevents directory context corruption

## Testing

Edge cases verified:
- `./test.sh -type` (missing value) → clear error message
- `./test.sh -type unit -config` (missing value) → clear error message
- `./test.sh --help` → exits cleanly
- Bash syntax validation passes