### PR TITLE
fix: add parameter validation and trap for proper cleanup in test.sh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,19 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      - name: Verify integration test config is present
+        run: |
+          if [ -z "${TESTS_CONFIG}" ]; then
+            echo "ERROR: TESTS_CONFIG secret is not set. Integration tests would be skipped."
+            exit 1
+          fi
       - name: Run integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          arch: x86_64
+          profile: pixel
+          disable-animations: true
+          emulator-boot-timeout: 900
+          emulator-options: -no-snapshot -noaudio -no-boot-anim -gpu swiftshader_indirect
           script: ./scripts/test.sh -type android -config "${TESTS_CONFIG}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,12 +41,6 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Verify integration test config is present
-        run: |
-          if [ -z "${TESTS_CONFIG}" ]; then
-            echo "ERROR: TESTS_CONFIG secret is not set. Integration tests would be skipped."
-            exit 1
-          fi
       - name: Run integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,5 +57,5 @@ jobs:
           profile: pixel
           disable-animations: true
           emulator-boot-timeout: 900
-          emulator-options: -no-snapshot -noaudio -no-boot-anim -gpu swiftshader_indirect
+          emulator-options: -no-snapshot -noaudio -no-boot-anim -no-window -gpu off
           script: ./scripts/test.sh -type android -config "${TESTS_CONFIG}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,12 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      - name: Verify integration test config is present
+        run: |
+          if [ -z "${TESTS_CONFIG}" ]; then
+            echo "ERROR: TESTS_CONFIG secret is not set. Integration tests would be skipped."
+            exit 1
+          fi
       - name: Run integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,8 @@ jobs:
           distribution: temurin
           java-version: '17'
           cache: gradle
+      - name: Install emulator dependencies
+        run: sudo apt-get install -y libpulse0
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.prepare-release.json
+++ b/.prepare-release.json
@@ -15,13 +15,13 @@
     },
     {
       "description": "SDK integration tutorial.",
-      "path": "docs/SDK-integration.md",
+      "path": "docs/SDK-Integration.md",
       "type": "version_replace",
       "match": "wultra-digital-onboarding:%VERSION%"
     },
     {
       "description": "SDK integration tutorial.",
-      "path": "docs/SDK-integration.md",
+      "path": "docs/SDK-Integration.md",
       "type": "versionstream_verify",
       "match": "`%VERSION_STREAM%`"
     },

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,6 +1,6 @@
 # BuildScript dependencies
 # some reasoning here https://discuss.gradle.org/t/place-for-properties-visible-from-both-buildsrc-and-project/18916
 
-systemProp.kotlinVersion=1.8.22
-systemProp.androidPluginVersion=8.7.2
-systemProp.dokkaVersion=1.8.20
+systemProp.kotlinVersion=2.4.10
+systemProp.androidPluginVersion=8.13.0
+systemProp.dokkaVersion=1.9.20

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -32,8 +32,8 @@ object Constants {
     }
 
     object Android {
-        const val compileSdkVersion = 33
+        const val compileSdkVersion = 36
         const val minSdkVersion = 28
-        const val buildToolsVersion = "34.0.0"
+        const val buildToolsVersion = "36.0.0"
     }
 }

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.0 (Aug, 2026)
+## 3.0.0-SNAPSHOT (Aug, 2026)
 
 - **⚠️ BREAKING**: `VerificationStateOtpData` now carries only `remainingAttempts`.
 - `ConfigurationResponseData` now includes optional `otpResendPeriodSeconds` (`null` on older backends that do not provide the field yet).

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 3.0.0-SNAPSHOT (Aug, 2026)
 
+- This release requires `PowerAuth SDK` version `2.0.0` or higher and `Networking` dependency version `2.0.0` or higher.
 - **⚠️ BREAKING**: `VerificationStateOtpData` now carries only `remainingAttempts`.
 - `ConfigurationResponseData` now includes optional `otpResendPeriodSeconds` (`null` on older backends that do not provide the field yet).
 - Fixed R8 minification ([#76](https://github.com/wultra/digital-onboarding-android/issues/76)).

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.0 (TBA)
+## 3.0.0 (Aug, 2026)
 
 - **⚠️ BREAKING**: `VerificationStateOtpData` now carries only `remainingAttempts`.
 - `ConfigurationResponseData` now includes optional `otpResendPeriodSeconds` (`null` on older backends that do not provide the field yet).

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -21,13 +21,14 @@ repositories {
 Then add a dependency
 
 ```kotlin
-implementation("com.wultra.android.digitalonboarding:wultra-digital-onboarding:1.3.0")
+implementation("com.wultra.android.digitalonboarding:wultra-digital-onboarding:3.0.0-SNAPSHOT")
 ```
 
 ## Guaranteed PowerAuth Compatibility
 
-| WDO SDK           | PowerAuth SDK |  
+| WDO SDK           | PowerAuth SDK |
 |-------------------|---------------|
+| `3.0.x`           | `2.0.x`       |
 | `2.0.x`           | `1.9.x`       |
 | `1.3.x`           | `1.9.x`       |
 | `1.1.x` - `1.2.x` | `1.8.x`       |

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -51,11 +51,12 @@ android {
     compileOptions {
         sourceCompatibility = Constants.Java.sourceCompatibility
         targetCompatibility = Constants.Java.targetCompatibility
-        kotlin {
-            compilerOptions {
-                jvmTarget.set(JvmTarget.fromTarget(Constants.Java.kotlinJvmTarget))
-                suppressWarnings.set(false)
-            }
+    }
+
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(Constants.Java.kotlinJvmTarget))
+            suppressWarnings.set(false)
         }
     }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -72,20 +72,20 @@ android {
 dependencies {
     // Bundled
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Constants.BuildScript.kotlinVersion}")
-    implementation("androidx.annotation:annotation:1.8.2")
-    implementation("com.google.code.gson:gson:2.11.0")
-    implementation("com.wultra.android.powerauth:powerauth-networking:1.5.0")
-    implementation("androidx.security:security-crypto-ktx:1.1.0-alpha06")
+    implementation("androidx.annotation:annotation:1.10.0")
+    implementation("com.google.code.gson:gson:2.14.0")
+    implementation("com.wultra.android.powerauth:powerauth-networking:2.0.0-SNAPSHOT")
+    implementation("androidx.security:security-crypto-ktx:1.1.0")
 
     // Dependencies
-    compileOnly("com.wultra.android.powerauth:powerauth-sdk:1.9.6")
+    compileOnly("com.wultra.android.powerauth:powerauth-sdk:2.0.0-SNAPSHOT")
 
     // Unit tests
     testImplementation("junit:junit:4.13.2")
 
     // Instrumentation tests
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test:core-ktx:1.6.1")
-    androidTestImplementation("com.wultra.android.powerauth:powerauth-sdk:1.9.6")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test:core-ktx:1.7.0")
+    androidTestImplementation("com.wultra.android.powerauth:powerauth-sdk:2.0.0-SNAPSHOT")
 }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,4 +1,5 @@
 @file:Suppress("UnstableApiUsage")
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 /*
  * Copyright 2023 Wultra s.r.o.
@@ -50,10 +51,11 @@ android {
     compileOptions {
         sourceCompatibility = Constants.Java.sourceCompatibility
         targetCompatibility = Constants.Java.targetCompatibility
-        //noinspection WrongGradleMethod
-        kotlinOptions {
-            jvmTarget = Constants.Java.kotlinJvmTarget
-            suppressWarnings = false
+        kotlin {
+            compilerOptions {
+                jvmTarget.set(JvmTarget.fromTarget(Constants.Java.kotlinJvmTarget))
+                suppressWarnings.set(false)
+            }
         }
     }
 
@@ -71,7 +73,7 @@ android {
 
 dependencies {
     // Bundled
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Constants.BuildScript.kotlinVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:${Constants.BuildScript.kotlinVersion}")
     implementation("androidx.annotation:annotation:1.10.0")
     implementation("com.google.code.gson:gson:2.14.0")
     implementation("com.wultra.android.powerauth:powerauth-networking:2.0.0-SNAPSHOT")

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -14,6 +14,6 @@
 # and limitations under the License.
 #
 
-VERSION_NAME=1.3.0-SNAPSHOT
+VERSION_NAME=3.0.0-SNAPSHOT
 GROUP_ID=com.wultra.android.digitalonboarding
 ARTIFACT_ID=wultra-digital-onboarding

--- a/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTestSupport.kt
+++ b/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTestSupport.kt
@@ -22,12 +22,13 @@ import com.google.gson.Gson
 import com.wultra.android.digitalonboarding.networking.model.ConfigurationDocument
 import com.wultra.android.digitalonboarding.networking.model.ConfigurationResponseData
 import com.wultra.android.powerauth.networking.error.ApiError
-import io.getlime.security.powerauth.core.ActivationStatus
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes
 import io.getlime.security.powerauth.exception.PowerAuthErrorException
 import io.getlime.security.powerauth.networking.exceptions.FailedApiException
 import io.getlime.security.powerauth.networking.response.CreateActivationResult
 import io.getlime.security.powerauth.networking.response.IActivationStatusListener
+import io.getlime.security.powerauth.sdk.PowerAuthActivationState
+import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus
 import io.getlime.security.powerauth.sdk.PowerAuthConfiguration
 import io.getlime.security.powerauth.sdk.PowerAuthSDK
 import okhttp3.OkHttpClient
@@ -152,7 +153,7 @@ internal class TestHelper(
         if (!paStatus.needVerification()) {
             throw SimpleError("Expected activation status to require verification")
         }
-        if (paStatus.state != ActivationStatus.State_Active) {
+        if (paStatus.state != PowerAuthActivationState.ACTIVE) {
             throw SimpleError("Expected activation state ACTIVE, got: ${paStatus.state}")
         }
     }
@@ -439,16 +440,16 @@ internal fun VerificationService.awaitFinishActivation(
 }
 
 // Loads current PowerAuth activation status using callback API and timeout protection.
-internal fun PowerAuthSDK.awaitActivationStatus(appContext: Context): ActivationStatus {
+internal fun PowerAuthSDK.awaitActivationStatus(appContext: Context): PowerAuthActivationStatus {
     val latch = CountDownLatch(1)
-    val statusRef = AtomicReference<ActivationStatus?>(null)
+    val statusRef = AtomicReference<PowerAuthActivationStatus?>(null)
     val errorRef = AtomicReference<Throwable?>(null)
 
     fetchActivationStatusWithCallback(
         appContext,
         object : IActivationStatusListener {
             // Stores successful activation status from callback.
-            override fun onActivationStatusSucceed(status: ActivationStatus?) {
+            override fun onActivationStatusSucceed(status: PowerAuthActivationStatus) {
                 statusRef.set(status)
                 latch.countDown()
             }

--- a/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTestSupport.kt
+++ b/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTestSupport.kt
@@ -479,12 +479,17 @@ internal fun PowerAuthSDK.awaitPersistActivation(appContext: Context, password: 
         appContext,
         password,
         object : IPersistActivationListener {
-            override fun onPersistActivationCompleted() {
+            override fun onPersistActivationSucceeded() {
                 latch.countDown()
             }
 
             override fun onPersistActivationFailed(t: Throwable) {
                 errorRef.set(t)
+                latch.countDown()
+            }
+
+            override fun onPersistActivationCancelled(userCancel: Boolean) {
+                errorRef.set(SimpleError("persistActivationWithPassword cancelled by user"))
                 latch.countDown()
             }
         },

--- a/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTestSupport.kt
+++ b/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTestSupport.kt
@@ -22,11 +22,11 @@ import com.google.gson.Gson
 import com.wultra.android.digitalonboarding.networking.model.ConfigurationDocument
 import com.wultra.android.digitalonboarding.networking.model.ConfigurationResponseData
 import com.wultra.android.powerauth.networking.error.ApiError
-import io.getlime.security.powerauth.exception.PowerAuthErrorCodes
 import io.getlime.security.powerauth.exception.PowerAuthErrorException
 import io.getlime.security.powerauth.networking.exceptions.FailedApiException
 import io.getlime.security.powerauth.networking.response.CreateActivationResult
 import io.getlime.security.powerauth.networking.response.IActivationStatusListener
+import io.getlime.security.powerauth.networking.response.IPersistActivationListener
 import io.getlime.security.powerauth.sdk.PowerAuthActivationState
 import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus
 import io.getlime.security.powerauth.sdk.PowerAuthConfiguration
@@ -143,10 +143,7 @@ internal class TestHelper(
         activation.awaitActivate(otp)
 
         // Persist with random password.
-        val persistCode = powerAuth.persistActivationWithPassword(appContext, UUID.randomUUID().toString())
-        if (persistCode != PowerAuthErrorCodes.SUCCEED) {
-            throw SimpleError("persistActivationWithPassword failed with code: ${persistCode}")
-        }
+        powerAuth.awaitPersistActivation(appContext, UUID.randomUUID().toString())
 
         // Verify PowerAuth status after activation.
         val paStatus = powerAuth.awaitActivationStatus(appContext)
@@ -471,6 +468,35 @@ internal fun PowerAuthSDK.awaitActivationStatus(appContext: Context): PowerAuthA
     }
 
     return statusRef.get() ?: throw SimpleError("PowerAuth activation status returned null")
+}
+
+// Persists PowerAuth activation with given password using async callback API.
+internal fun PowerAuthSDK.awaitPersistActivation(appContext: Context, password: String) {
+    val latch = CountDownLatch(1)
+    val errorRef = AtomicReference<Throwable?>(null)
+
+    persistActivationWithPassword(
+        appContext,
+        password,
+        object : IPersistActivationListener {
+            override fun onPersistActivationCompleted() {
+                latch.countDown()
+            }
+
+            override fun onPersistActivationFailed(t: Throwable) {
+                errorRef.set(t)
+                latch.countDown()
+            }
+        },
+    )
+
+    if (!latch.await(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+        throw SimpleError("Timed out waiting for persistActivationWithPassword")
+    }
+
+    errorRef.get()?.let {
+        throw SimpleError("persistActivationWithPassword failed: ${it.message}")
+    }
 }
 
 // Calls DemoEndpoints OTP endpoint for activation flow.

--- a/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTestSupport.kt
+++ b/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTestSupport.kt
@@ -22,7 +22,6 @@ import com.google.gson.Gson
 import com.wultra.android.digitalonboarding.networking.model.ConfigurationDocument
 import com.wultra.android.digitalonboarding.networking.model.ConfigurationResponseData
 import com.wultra.android.powerauth.networking.error.ApiError
-import io.getlime.security.powerauth.exception.PowerAuthErrorException
 import io.getlime.security.powerauth.networking.exceptions.FailedApiException
 import io.getlime.security.powerauth.networking.response.CreateActivationResult
 import io.getlime.security.powerauth.networking.response.IActivationStatusListener
@@ -244,7 +243,7 @@ internal fun ConfigurationDocument.getMockDocumentToUpload(side: DocumentSide): 
 
 // Detects whether API error maps to known PowerAuth transport/runtime error families.
 internal fun ApiError.isPowerAuthError(): Boolean {
-    return e is FailedApiException || e is PowerAuthErrorException
+    return e is FailedApiException
 }
 
 // Resolves OTP retrieval strategy from environment configuration.

--- a/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTests.kt
+++ b/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTests.kt
@@ -20,8 +20,9 @@ import android.util.Log
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.wultra.android.digitalonboarding.log.WDOLogger
-import io.getlime.security.powerauth.core.ActivationStatus
+import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus
 import io.getlime.security.powerauth.core.Password
+import io.getlime.security.powerauth.sdk.PowerAuthActivationState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -247,10 +248,10 @@ class IntegrationTests {
                 state = finishResult.state
 
                 val originalStatus = helper.powerAuth.awaitActivationStatus(appContext)
-                assertEquals(ActivationStatus.State_Removed, originalStatus.state)
+                assertEquals(PowerAuthActivationState.REMOVED, originalStatus.state)
 
                 val newStatus = newPowerAuth.awaitActivationStatus(appContext)
-                assertEquals(ActivationStatus.State_Active, newStatus.state)
+                assertEquals(PowerAuthActivationState.ACTIVE, newStatus.state)
                 assertFalse(newStatus.needVerification())
             }
 
@@ -293,7 +294,7 @@ class IntegrationTests {
 
             // After cancellation, PowerAuth should be removed.
             val paStatus = helper.powerAuth.awaitActivationStatus(appContext)
-            assertEquals(ActivationStatus.State_Removed, paStatus.state)
+            assertEquals(PowerAuthActivationState.REMOVED, paStatus.state)
         }
     }
 

--- a/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTests.kt
+++ b/library/src/androidTest/java/com/wultra/android/digitalonboarding/IntegrationTests.kt
@@ -20,7 +20,6 @@ import android.util.Log
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.wultra.android.digitalonboarding.log.WDOLogger
-import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus
 import io.getlime.security.powerauth.core.Password
 import io.getlime.security.powerauth.sdk.PowerAuthActivationState
 import org.junit.Assert.assertEquals

--- a/library/src/main/java/com/wultra/android/digitalonboarding/ActivationService.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/ActivationService.kt
@@ -83,7 +83,7 @@ class ActivationService(
 
     /** Status of the Onboarding Activation */
     enum class Status {
-        /** Activation is in the progress */
+        /** Activation is in progress */
         ACTIVATION_IN_PROGRESS,
         /** Activation was already finished, not waiting for the verification */
         VERIFICATION_IN_PROGRESS,
@@ -111,8 +111,8 @@ class ActivationService(
      * The default value is "en".
      *
      * Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
-     * Response texts are based on this setting. For example, when "de" is set, server
-     * will return error texts and other in German (if available).
+     * Response texts are based on this setting. For example, when "de" is set,
+     * the server will return error texts and other in German (if available).
      */
     var acceptLanguage: String
         set(value) { api.acceptLanguage = value }
@@ -144,7 +144,7 @@ class ActivationService(
      * If the activation process is in progress.
      *
      * Note that when the result is `true` it can be already discontinued on the server.
-     * Calling `status` in such case is recommended.
+     * Calling `status` in such a case is recommended.
      */
     fun hasActiveProcess() = processId != null
 

--- a/library/src/main/java/com/wultra/android/digitalonboarding/PowerAuthExtensions.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/PowerAuthExtensions.kt
@@ -13,13 +13,13 @@
 
 package com.wultra.android.digitalonboarding
 
-import io.getlime.security.powerauth.core.ActivationStatus
+import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus
 import io.getlime.security.powerauth.networking.exceptions.FailedApiException
 
 fun FailedApiException.onboardingOtpRemainingAttempts(): Int? = responseJson?.get("remainingAttempts")?.asInt
 fun FailedApiException.allowOnboardingOtpRetry() = onboardingOtpRemainingAttempts()?.let { it > 0 }
 
-private fun ActivationStatus.activationFlags() = (customObject?.let { it["activationFlags"] as? List<*> })?.filterIsInstance<String>() ?: emptyList()
-fun ActivationStatus.verificationPending() = activationFlags().contains("VERIFICATION_PENDING")
-fun ActivationStatus.verificationInProgress() = activationFlags().contains("VERIFICATION_IN_PROGRESS")
-fun ActivationStatus.needVerification() = verificationPending() || verificationInProgress()
+private fun PowerAuthActivationStatus.activationFlags() = (customObject?.let { it["activationFlags"] as? List<*> })?.filterIsInstance<String>() ?: emptyList()
+fun PowerAuthActivationStatus.verificationPending() = activationFlags().contains("VERIFICATION_PENDING")
+fun PowerAuthActivationStatus.verificationInProgress() = activationFlags().contains("VERIFICATION_IN_PROGRESS")
+fun PowerAuthActivationStatus.needVerification() = verificationPending() || verificationInProgress()

--- a/library/src/main/java/com/wultra/android/digitalonboarding/VerificationService.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/VerificationService.kt
@@ -42,13 +42,11 @@ import com.wultra.android.powerauth.networking.error.ApiError
 import com.wultra.android.powerauth.networking.error.ApiErrorCode
 import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus
 import io.getlime.security.powerauth.core.Password
-import io.getlime.security.powerauth.exception.PowerAuthErrorCodes
 import io.getlime.security.powerauth.networking.response.CreateActivationResult
 import io.getlime.security.powerauth.networking.response.IActivationStatusListener
 import io.getlime.security.powerauth.networking.response.IBeginPasswordChangeListener
 import io.getlime.security.powerauth.networking.response.ICreateActivationListener
 import io.getlime.security.powerauth.networking.response.IPersistActivationListener
-import io.getlime.security.powerauth.networking.response.IValidatePasswordListener
 import io.getlime.security.powerauth.sdk.PowerAuthActivation
 import io.getlime.security.powerauth.sdk.PowerAuthActivationState
 import io.getlime.security.powerauth.sdk.PowerAuthPasswordChangeData

--- a/library/src/main/java/com/wultra/android/digitalonboarding/VerificationService.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/VerificationService.kt
@@ -45,11 +45,13 @@ import io.getlime.security.powerauth.core.Password
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes
 import io.getlime.security.powerauth.networking.response.CreateActivationResult
 import io.getlime.security.powerauth.networking.response.IActivationStatusListener
+import io.getlime.security.powerauth.networking.response.IBeginPasswordChangeListener
 import io.getlime.security.powerauth.networking.response.ICreateActivationListener
 import io.getlime.security.powerauth.networking.response.IPersistActivationListener
 import io.getlime.security.powerauth.networking.response.IValidatePasswordListener
 import io.getlime.security.powerauth.sdk.PowerAuthActivation
 import io.getlime.security.powerauth.sdk.PowerAuthActivationState
+import io.getlime.security.powerauth.sdk.PowerAuthPasswordChangeData
 import io.getlime.security.powerauth.sdk.PowerAuthSDK
 import okhttp3.OkHttpClient
 
@@ -657,7 +659,7 @@ class VerificationService(
      *
      * @param newPowerAuthInstance PowerAuth instance where to create new activation. This instance must not have an existing activation.
      * @param newActivationName Name of the new activation to be created on `newPowerAuthInstance`.
-     * @param newPassword Password to protect the new activation. In case `validatePassword` is `true`, this password must match the password of the original activation.
+     * @param newPassword Password to protect the new activation.
      * @param validatePassword If set to `true`, the method verifies that the provided `newPassword` matches the password of the original activation.
      * @param userIdentification Optional user identification object to be sent to the server during the finish activation process.
      */
@@ -770,7 +772,7 @@ class VerificationService(
      *
      * @param required Whether the password validation is required.
      * @param password Password to validate.
-     * @param callback Callback with the error if any.
+     * @param callback Callback with the error, if any.
      */
     private fun validatePasswordIfRequired(
         required: Boolean,
@@ -781,15 +783,16 @@ class VerificationService(
             // Password validation isn't required
             callback(null)
         } else {
-            powerAuthSDK.validatePassword(
+            // TODO: Since PowerAuth SDK 2.0 the `validatePassword` method is removed, we are using `beginPasswordChange` instead.
+            // This is a workaround to validate the password without changing it. Backend should implement new endpoint for password validation.
+            powerAuthSDK.beginPasswordChange(
                 appContext,
                 password,
-                object : IValidatePasswordListener {
-                    override fun onPasswordValid() {
+                object : IBeginPasswordChangeListener {
+                    override fun onBeginPasswordChangeSucceed(passwordChangeData: PowerAuthPasswordChangeData) {
                         callback(null)
                     }
-
-                    override fun onPasswordValidationFailed(t: Throwable) {
+                    override fun onBeginPasswordChangeFailed(t: Throwable) {
                         WDOLogger.i("Password validation failed.")
                         callback(t)
                     }

--- a/library/src/main/java/com/wultra/android/digitalonboarding/VerificationService.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/VerificationService.kt
@@ -40,7 +40,7 @@ import com.wultra.android.powerauth.networking.IApiCallResponseListener
 import com.wultra.android.powerauth.networking.data.StatusResponse
 import com.wultra.android.powerauth.networking.error.ApiError
 import com.wultra.android.powerauth.networking.error.ApiErrorCode
-import io.getlime.security.powerauth.core.ActivationStatus
+import io.getlime.security.powerauth.sdk.PowerAuthActivationStatus
 import io.getlime.security.powerauth.core.Password
 import io.getlime.security.powerauth.exception.PowerAuthErrorCodes
 import io.getlime.security.powerauth.networking.response.CreateActivationResult
@@ -48,6 +48,7 @@ import io.getlime.security.powerauth.networking.response.IActivationStatusListen
 import io.getlime.security.powerauth.networking.response.ICreateActivationListener
 import io.getlime.security.powerauth.networking.response.IValidatePasswordListener
 import io.getlime.security.powerauth.sdk.PowerAuthActivation
+import io.getlime.security.powerauth.sdk.PowerAuthActivationState
 import io.getlime.security.powerauth.sdk.PowerAuthSDK
 import okhttp3.OkHttpClient
 
@@ -70,7 +71,7 @@ enum class ConsentResponse {
  * Digital Onboarding Verification Service
  *
  * @property appContext Application context
- * @property powerAuthSDK Configured PowerAuthSDK instance. This instance needs to be with valid activation otherwise you'll get errors.
+ * @property powerAuthSDK Configured PowerAuthSDK instance. This instance needs to be with valid activation, otherwise you'll get errors.
  * @constructor Creates the instance
  *
  * @param identityServerUrl Base URL for service requests. Usually ending with `enrollment-onboarding-server`.
@@ -87,8 +88,8 @@ class VerificationService(
      * The default value is "en".
      *
      * Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
-     * Response texts are based on this setting. For example, when "de" is set, server
-     * will return error texts and other in German (if available).
+     * Response texts are based on this setting. For example, when "de" is set,
+     * the server will return error texts and other in German (if available).
      */
     var acceptLanguage: String
         set(value) { api.acceptLanguage = value }
@@ -112,7 +113,7 @@ class VerificationService(
             val key = storageCacheKey ?: return null
             val cacheData = storage.getValue(key) ?: return null
             return runCatching { VerificationScanProcess(cacheData) }
-                .onFailure { WDOLogger.e("Failed to decode scan process cache: ${it}") }
+                .onFailure { WDOLogger.e("Failed to decode scan process cache: $it") }
                 .getOrNull()
         }
         set(value) {
@@ -140,7 +141,10 @@ class VerificationService(
                 lastStatus = result
 
                 when (result.responseObject.status) {
-                    IdentityVerificationStatus.FAILED, IdentityVerificationStatus.REJECTED, IdentityVerificationStatus.NOT_INITIALIZED, IdentityVerificationStatus.ACCEPTED -> {
+                    IdentityVerificationStatus.FAILED,
+                    IdentityVerificationStatus.REJECTED,
+                    IdentityVerificationStatus.NOT_INITIALIZED,
+                    IdentityVerificationStatus.ACCEPTED -> {
                         WDOLogger.d("We reached endstate, clearing cache")
                         cachedProcess = null
                     }
@@ -297,7 +301,7 @@ class VerificationService(
     }
 
     /**
-     * Starts the verification process with the user consent.
+     * Starts the verification process with the user's consent.
      *
      * @param consentApprovedByUser User response for the consent.
      * @param callback Callback with the result.
@@ -409,7 +413,8 @@ class VerificationService(
                         .firstOrNull { it.type == file.type }
                         ?.originalDocumentIdFor(file.side)
 
-                    // In this case, the originalDocumentId is not available in the file object, but we can find it in the cached process by matching the document type and side.
+                    // In this case, the originalDocumentId is not available in the file object, but we can find it in the cached process
+                    // by matching the document type and side.
                     // This allows us to reuse the scanned document without forcing the user to scan it again.
                     if (serverId != null) {
                         WDOLogger.d("Document ${file.type} is missing originalDocumentId, using cached ID $serverId.")
@@ -509,7 +514,7 @@ class VerificationService(
     }
 
     /**
-     * Restarts verification. When successfully called, intro screen should be presented.
+     * Restarts verification. When successfully called, an intro screen should be presented.
      *
      * @param callback Callback with the result.
      */
@@ -539,7 +544,8 @@ class VerificationService(
     }
 
     /**
-     * Cancels the whole activation/verification. After this it's no longer call any API endpoint and PowerAuth activation should be removed.
+     * Cancels the whole activation/verification. After this it no longer calls any API endpoint
+     * and PowerAuth activation should be removed.
      *
      * @param callback Callback with the result.
      */
@@ -565,7 +571,7 @@ class VerificationService(
     }
 
     /**
-     * Verify OTP that user entered as a last step of the verification.
+     * Verify OTP that the user entered as a last step of the verification.
      *
      * @param otp User entered OTP.
      * @param callback Callback with the result.
@@ -756,7 +762,7 @@ class VerificationService(
         callback: (Throwable?) -> Unit,
     ) {
         if (!required) {
-            // Password validation not required
+            // Password validation isn't required
             callback(null)
         } else {
             powerAuthSDK.validatePassword(
@@ -824,7 +830,7 @@ class VerificationService(
     object ActivationNotActiveException: Exception("PowerAuth instance is not in the active state.")
     /** Verification status needs to be fetched first */
     object ActivationMissingStatusException: Exception("Verification status needs to be fetched first.")
-    /** OTP failed to verify. Refresh status to retrieve current status */
+    /** OTP failed to verify. Refresh status to retrieve the current status */
     object OTPFailedException: Exception("OTP failed to verify.")
 
     // Private helper methods
@@ -864,8 +870,8 @@ class VerificationService(
             powerAuthSDK.fetchActivationStatusWithCallback(
                 appContext,
                 object : IActivationStatusListener {
-                    override fun onActivationStatusSucceed(status: ActivationStatus?) {
-                        if (status?.state != ActivationStatus.State_Active) {
+                    override fun onActivationStatusSucceed(status: PowerAuthActivationStatus) {
+                        if (status.state != PowerAuthActivationState.ACTIVE) {
                             WDOLogger.e("PowerAuth status not active.")
                             listener?.powerAuthActivationStatusChanged(this@VerificationService, status)
                             markCompleted(Fail(ApiError(ActivationNotActiveException)), callback)
@@ -910,23 +916,23 @@ class VerificationService(
 }
 
 /**
- * Listener of the Onboarding Verification Service that can listen on Verification Status and PowerAuth Status changes.
- *
+ * Listener of the Onboarding Verification Service that can listen to Verification Status and PowerAuth Status changes.
  */
 interface VerificationServiceListener {
 
     /**
      * Called when PowerAuth activation status changed.
      *
-     * Note that this happens only when error is returned in some of the Verification endpoints and this error indicates PowerAuth status change.
+     * Note that this happens only when an error is returned in some of the Verification endpoints,
+     * and this error indicates PowerAuth status change.
      *
      * @param service Origin service
      * @param status Status
      */
-    fun powerAuthActivationStatusChanged(service: VerificationService, status: ActivationStatus?)
+    fun powerAuthActivationStatusChanged(service: VerificationService, status: PowerAuthActivationStatus?)
 
     /**
-     * Called when state of the verification has changed.
+     * Called when the state of the verification has changed.
      *
      * @param service Origin service
      * @param status Status

--- a/library/src/main/java/com/wultra/android/digitalonboarding/VerificationService.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/VerificationService.kt
@@ -46,6 +46,7 @@ import io.getlime.security.powerauth.exception.PowerAuthErrorCodes
 import io.getlime.security.powerauth.networking.response.CreateActivationResult
 import io.getlime.security.powerauth.networking.response.IActivationStatusListener
 import io.getlime.security.powerauth.networking.response.ICreateActivationListener
+import io.getlime.security.powerauth.networking.response.IPersistActivationListener
 import io.getlime.security.powerauth.networking.response.IValidatePasswordListener
 import io.getlime.security.powerauth.sdk.PowerAuthActivation
 import io.getlime.security.powerauth.sdk.PowerAuthActivationState
@@ -717,16 +718,31 @@ class VerificationService(
 
                                 override fun onActivationCreateSucceed(result: CreateActivationResult) {
                                     // New activation created, now persist it with the provided password
-                                    val persistResult = newPowerAuthInstance.persistActivationWithPassword(appContext, newPassword)
-                                    if (persistResult == PowerAuthErrorCodes.SUCCEED) {
-                                        // New activation persisted
-                                        markCompleted(VerificationStateSuccessData, callback)
-                                    } else {
-                                        // Failed to persist new activation, clean up
-                                        clearPaInstanceIfNeeded()
-                                        WDOLogger.e("Failed to persist PowerAuth activation. Code: $persistResult")
-                                        markCompleted(Fail(ApiError(Exception("Failed to persist PowerAuth activation. Code: $persistResult"))), callback)
-                                    }
+                                    newPowerAuthInstance.persistActivationWithPassword(
+                                        appContext,
+                                        newPassword,
+                                        object : IPersistActivationListener {
+                                            override fun onPersistActivationSucceeded() {
+                                                // New activation persisted
+                                                markCompleted(VerificationStateSuccessData, callback)
+                                            }
+
+                                            override fun onPersistActivationFailed(t: Throwable) {
+                                                // Failed to persist new activation, clean up
+                                                clearPaInstanceIfNeeded()
+                                                WDOLogger.e("Failed to persist PowerAuth activation. $t")
+                                                markCompleted(Fail(ApiError(t)), callback)
+                                            }
+
+                                            override fun onPersistActivationCancelled(userCancel: Boolean) {
+                                                // Failed to persist new activation, clean up
+                                                clearPaInstanceIfNeeded()
+                                                val error = Exception("Failed to persist PowerAuth activation: cancelled by user: $userCancel")
+                                                WDOLogger.e(error.message ?: "Failed to persist PowerAuth activation")
+                                                markCompleted(Fail(ApiError(error)), callback)
+                                            }
+                                        }
+                                    )
                                 }
 
                                 override fun onActivationCreateFailed(t: Throwable) {

--- a/library/src/main/java/com/wultra/android/digitalonboarding/networking/CustomerOnboardingApi.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/networking/CustomerOnboardingApi.kt
@@ -117,10 +117,10 @@ internal class CustomerOnboardingApi(
     }
 
     /**
-     * Resends the OTP for users convenience (for example when SMS was not received by the user).
+     * Resends the OTP for users' convenience (for example, when the user did not receive SMS).
      *
-     * Note that there will be some frequency limit implemented by the server. Default is 30 seconds
-     * but we advise to consult this with the backend developers.
+     * Note that there will be some frequency limits implemented by the server. Default is 30 seconds,
+     * but we advise consulting this with the backend developers.
      *
      * Encrypted with the ECIES application scope.
      *

--- a/library/src/main/java/com/wultra/android/digitalonboarding/networking/CustomerVerificationApi.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/networking/CustomerVerificationApi.kt
@@ -75,7 +75,7 @@ internal class CustomerVerificationApi(
         private val consentApproveEndpoint = EndpointAuthenticated<ConsentApproveRequest, ConsentApproveResponse>("/api/identity/consent/approve", "/api/identity/consent/approve")
         private val docsStatusEndpoint = EndpointAuthenticatedWithToken<DocumentsStatusRequest, DocumentsStatusResponse>("api/identity/document/status", "possession_universal")
         private val documentSdkInitEndpoint = EndpointAuthenticated<SDKInitRequest, SDKInitResponse>("/api/identity/document/init-sdk", "/api/identity/document/init-sdk", E2EEConfiguration.ACTIVATION_SCOPE)
-        private val submitDocsEndpointV2 = EndpointAuthenticated<DocumentSubmitRequest, DocumentSubmitResponse>("api/v2/identity/document/submit", "possession_universal", E2EEConfiguration.ACTIVATION_SCOPE)
+        private val submitDocsEndpointV2 = EndpointAuthenticatedWithToken<DocumentSubmitRequest, DocumentSubmitResponse>("api/v2/identity/document/submit", "possession_universal", E2EEConfiguration.ACTIVATION_SCOPE)
         private val presenceCheckEndpoint = EndpointAuthenticated<PresenceCheckRequest, PresenceCheckResponse>("api/identity/presence-check/init", "/api/identity/presence-check/init", E2EEConfiguration.ACTIVATION_SCOPE)
         private val presenceCheckSubmitEndpoint = EndpointAuthenticated<PresenceCheckSubmitRequest, StatusResponse>("api/identity/presence-check/submit", "/api/identity/presence-check/submit")
         private val resendOtpEndpoint = EndpointAuthenticated<VerificationResendOtpRequest, ResendOtpResponse>("api/identity/otp/resend", "/api/identity/otp/resend")
@@ -197,7 +197,6 @@ internal class CustomerVerificationApi(
         post(
             DocumentSubmitRequest(data),
             submitDocsEndpointV2,
-            PowerAuthAuthentication.possession(),
             null,
             object : OkHttpBuilderInterceptor {
                 override fun intercept(builder: OkHttpClient.Builder) {

--- a/library/src/main/java/com/wultra/android/digitalonboarding/networking/CustomerVerificationApi.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/networking/CustomerVerificationApi.kt
@@ -68,19 +68,19 @@ internal class CustomerVerificationApi(
 : Api(identityServerUrl, okHttpClient, powerAuthSDK, Utils.defaultGsonBuilder(), appContext) {
 
     companion object {
-        private val statusEndpoint = EndpointSignedWithToken<EmptyRequest, VerificationStatusResponse>("api/identity/status", "possession_universal")
-        private val startEndpoint = EndpointSigned<StartRequest, StatusResponse>("api/identity/init", "/api/identity/init")
-        private val cancelEndpoint = EndpointSigned<CancelRequest, StatusResponse>("api/identity/cleanup", "/api/identity/cleanup")
-        private val consentTextEndpoint = EndpointSignedWithToken<ConsentRequest, ConsentTextResponse>("/api/identity/consent/text", "possession_universal")
-        private val consentApproveEndpoint = EndpointSigned<ConsentApproveRequest, ConsentApproveResponse>("/api/identity/consent/approve", "/api/identity/consent/approve")
-        private val docsStatusEndpoint = EndpointSignedWithToken<DocumentsStatusRequest, DocumentsStatusResponse>("api/identity/document/status", "possession_universal")
-        private val documentSdkInitEndpoint = EndpointSigned<SDKInitRequest, SDKInitResponse>("/api/identity/document/init-sdk", "/api/identity/document/init-sdk", E2EEConfiguration.ACTIVATION_SCOPE)
-        private val submitDocsEndpointV2 = EndpointSignedWithToken<DocumentSubmitRequest, DocumentSubmitResponse>("api/v2/identity/document/submit", "possession_universal", E2EEConfiguration.ACTIVATION_SCOPE)
-        private val presenceCheckEndpoint = EndpointSigned<PresenceCheckRequest, PresenceCheckResponse>("api/identity/presence-check/init", "/api/identity/presence-check/init", E2EEConfiguration.ACTIVATION_SCOPE)
-        private val presenceCheckSubmitEndpoint = EndpointSigned<PresenceCheckSubmitRequest, StatusResponse>("api/identity/presence-check/submit", "/api/identity/presence-check/submit")
-        private val resendOtpEndpoint = EndpointSigned<VerificationResendOtpRequest, ResendOtpResponse>("api/identity/otp/resend", "/api/identity/otp/resend")
+        private val statusEndpoint = EndpointAuthenticatedWithToken<EmptyRequest, VerificationStatusResponse>("api/identity/status", "possession_universal")
+        private val startEndpoint = EndpointAuthenticated<StartRequest, StatusResponse>("api/identity/init", "/api/identity/init")
+        private val cancelEndpoint = EndpointAuthenticated<CancelRequest, StatusResponse>("api/identity/cleanup", "/api/identity/cleanup")
+        private val consentTextEndpoint = EndpointAuthenticatedWithToken<ConsentRequest, ConsentTextResponse>("/api/identity/consent/text", "possession_universal")
+        private val consentApproveEndpoint = EndpointAuthenticated<ConsentApproveRequest, ConsentApproveResponse>("/api/identity/consent/approve", "/api/identity/consent/approve")
+        private val docsStatusEndpoint = EndpointAuthenticatedWithToken<DocumentsStatusRequest, DocumentsStatusResponse>("api/identity/document/status", "possession_universal")
+        private val documentSdkInitEndpoint = EndpointAuthenticated<SDKInitRequest, SDKInitResponse>("/api/identity/document/init-sdk", "/api/identity/document/init-sdk", E2EEConfiguration.ACTIVATION_SCOPE)
+        private val submitDocsEndpointV2 = EndpointAuthenticated<DocumentSubmitRequest, DocumentSubmitResponse>("api/v2/identity/document/submit", "possession_universal", E2EEConfiguration.ACTIVATION_SCOPE)
+        private val presenceCheckEndpoint = EndpointAuthenticated<PresenceCheckRequest, PresenceCheckResponse>("api/identity/presence-check/init", "/api/identity/presence-check/init", E2EEConfiguration.ACTIVATION_SCOPE)
+        private val presenceCheckSubmitEndpoint = EndpointAuthenticated<PresenceCheckSubmitRequest, StatusResponse>("api/identity/presence-check/submit", "/api/identity/presence-check/submit")
+        private val resendOtpEndpoint = EndpointAuthenticated<VerificationResendOtpRequest, ResendOtpResponse>("api/identity/otp/resend", "/api/identity/otp/resend")
         private val otpVerifyEndpoint = EndpointBasic<VerifyOtpRequest, VerifyOtpResponse>("api/identity/otp/verify", E2EEConfiguration.ACTIVATION_SCOPE)
-        private val finishVerificationEndpoint = EndpointSignedWithToken<FinishActivationRequest, FinishActivationResponse>("api/identity/activation", "possession_universal", E2EEConfiguration.ACTIVATION_SCOPE)
+        private val finishVerificationEndpoint = EndpointAuthenticatedWithToken<FinishActivationRequest, FinishActivationResponse>("api/identity/activation", "possession_universal", E2EEConfiguration.ACTIVATION_SCOPE)
     }
 
     /**
@@ -185,7 +185,7 @@ internal class CustomerVerificationApi(
     }
 
     /**
-     * Submits documents necessary for identity verification (like photos of ID or passport).
+     * Submits the documents necessary for identity verification (like photos of ID or passport).
      *
      * Encrypted with the ECIES activation scope.
      *
@@ -197,8 +197,9 @@ internal class CustomerVerificationApi(
         post(
             DocumentSubmitRequest(data),
             submitDocsEndpointV2,
+            PowerAuthAuthentication.possession(),
             null,
-            object: OkHttpBuilderInterceptor {
+            object : OkHttpBuilderInterceptor {
                 override fun intercept(builder: OkHttpClient.Builder) {
                     // document upload can take some time
                     builder.callTimeout(120, TimeUnit.SECONDS)
@@ -212,7 +213,7 @@ internal class CustomerVerificationApi(
     }
 
     /**
-     * Asks for status of already uploaded documents.
+     * Asks for the status of already uploaded documents.
      *
      * @param processId ID of the process.
      * @param listener Result listener.
@@ -264,7 +265,7 @@ internal class CustomerVerificationApi(
     }
 
     /**
-     * OTP resend  in case that the user didn't received it.
+     * OTP resend in case that the user didn't receive it.
      *
      * @param processId ID of the process.
      * @param listener Result listener.

--- a/library/src/main/java/com/wultra/android/digitalonboarding/networking/model/ConfigurationObjects.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/networking/model/ConfigurationObjects.kt
@@ -43,7 +43,7 @@ class ConfigurationResponse(
 
 /** Configuration response */
 data class ConfigurationResponseData(
-    /** Is the onboarding process enabled */
+    /** Is the onboarding process enabled? */
     @SerializedName("enabled") val enabled: Boolean,
     /** Is OTP required for the first part - identification/activation. */
     @SerializedName("otpForIdentification") val otpForIdentification: Boolean,
@@ -51,7 +51,7 @@ data class ConfigurationResponseData(
     @SerializedName("otpForIdentityVerification") val otpForIdentityVerification: Boolean,
     /** Is the onboarding process configured with temporary activation that should be exchanged for the permanent one. */
     @SerializedName("useTemporaryActivation") val useTemporaryActivation: Boolean,
-    /** Time in seconds user needs to wait between OTP resend calls. Null when backend doesn't provide the value. */
+    /** Time in seconds user needs to wait between OTP resend calls. Null when the backend doesn't provide the value. */
     @SerializedName("otpResendPeriodSeconds") val otpResendPeriodSeconds: Int?,
     /** Documents required for identity verification. */
     @SerializedName("documents") val documents: ConfigurationDocuments

--- a/library/src/main/java/com/wultra/android/digitalonboarding/networking/model/CustomerVerificationNetworkObjects.kt
+++ b/library/src/main/java/com/wultra/android/digitalonboarding/networking/model/CustomerVerificationNetworkObjects.kt
@@ -215,7 +215,7 @@ internal class VerifyOtpResponseData(
 internal class SDKInitResponseDataAttributesDeserializer: JsonDeserializer<SDKInitResponseDataAttributes> {
 
     override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): SDKInitResponseDataAttributes {
-        // This is pretty big oversimplification, but in general, we expect 1 string property with an unknown key (property name).
+        // This is a pretty big oversimplification, but in general, we expect 1 string property with an unknown key (property name).
         // If this does not fit the customer needs, we are going to need to provide this API as generic or make it provider-based for
         // different SDK providers.
         val firstEntry = json.asJsonObject.asMap().entries.firstOrNull() ?: throw JsonParseException("No attribute in the response SDKInitResponseDataAttributes")

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,22 +29,35 @@ verify_android_instrumentation_results() {
         exit 1
     fi
 
-    # shellcheck disable=SC2012
-    local report_files
-    report_files=$(ls "${report_dir}"/*.xml 2>/dev/null || true)
-    if [ -z "${report_files}" ]; then
+    local report_files=()
+    while IFS= read -r xml; do
+        report_files+=("${xml}")
+    done < <(find "${report_dir}" -type f -name "*.xml" | sort)
+
+    if [ "${#report_files[@]}" -eq 0 ]; then
         echo "ERROR: Android test reports were not generated in ${report_dir}"
         exit 1
     fi
 
-    while IFS= read -r xml; do
+    for xml in "${report_files[@]}"; do
         local tests
         local skipped
-        tests=$(grep -oE 'tests="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
-        skipped=$(grep -oE 'skipped="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
+
+        tests=$(grep -c '<testcase ' "${xml}" || echo "0")
+        skipped=$(grep -c '<skipped' "${xml}" || echo "0")
+
+        if [ "${tests}" -eq 0 ]; then
+            tests=$(grep -oE 'tests="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
+        fi
+        if [ "${skipped}" -eq 0 ]; then
+            skipped=$(grep -oE 'skipped="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
+        fi
+
         total_tests=$((total_tests + tests))
         skipped_tests=$((skipped_tests + skipped))
-    done <<< "${report_files}"
+    done
+
+    echo "Android instrumentation results: total=${total_tests}, skipped=${skipped_tests}, reportFiles=${#report_files[@]}"
 
     if [ "${total_tests}" -eq 0 ] || [ "${total_tests}" -eq "${skipped_tests}" ]; then
         echo "ERROR: Android instrumentation tests were not executed successfully (total=${total_tests}, skipped=${skipped_tests})."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -52,6 +52,25 @@ verify_android_instrumentation_results() {
     fi
 }
 
+select_running_emulator_serial() {
+    local serials
+    serials=$(adb devices | awk '/^emulator-[0-9]+[[:space:]]+device$/ { print $1 }')
+
+    if [ -z "${serials}" ]; then
+        echo "ERROR: No running Android emulator in 'device' state found via adb."
+        echo "adb devices output:"
+        adb devices
+        exit 1
+    fi
+
+    local selected
+    selected=$(printf '%s\n' "${serials}" | head -n 1)
+    echo "Detected emulator serial(s):"
+    printf '%s\n' "${serials}"
+    echo "Using emulator serial: ${selected}"
+    export ANDROID_SERIAL="${selected}"
+}
+
 # Parse parameters of this script
 while [[ $# -gt 0 ]]
 do
@@ -94,6 +113,7 @@ fi
 if [ "${TYPE}" == "unit" ] ; then
     ./gradlew :library:testDebugUnitTest
 elif [ "${TYPE}" == "android" ] ; then
+    select_running_emulator_serial
     ./gradlew :library:connectedDebugAndroidTest
     verify_android_instrumentation_results
 else

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,12 +29,12 @@ parse_arguments() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -type)
-                [ $# -ge 2 ] || die "Missing value for -type."
+                [ $# -ge 2 ] && [[ "$2" != -* ]] || die "Missing value for -type."
                 TYPE="$2"
                 shift 2
                 ;;
             -config)
-                [ $# -ge 2 ] || die "Missing value for -config."
+                [ $# -ge 2 ] && [[ "$2" != -* ]] || die "Missing value for -config."
                 CONFIG_JSON="$2"
                 shift 2
                 ;;
@@ -169,10 +169,12 @@ main() {
     parse_arguments "$@"
     validate_arguments
 
+    trap 'popd 2>/dev/null || true' EXIT
     pushd "${SCRIPT_FOLDER}/.." >/dev/null
     write_android_test_config_if_provided
     run_tests
     popd >/dev/null
+    trap - EXIT
 }
 
 main "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,6 +5,7 @@ set -u # stop when undefined variable is used
 #set -x # print all execution (good for debugging)
 
 SCRIPT_FOLDER=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ANDROID_TEST_RESULTS_DIR="library/build/outputs/androidTest-results/connected"
 
 TYPE=""
 CONFIG_JSON=""
@@ -16,6 +17,39 @@ print_usage() {
     echo "            android Runs Android instrumentation tests (:library:connectedDebugAndroidTest)"
     echo "  -config   Optional JSON content that will be written to"
     echo "            library/src/androidTest/assets/config.json"
+}
+
+verify_android_instrumentation_results() {
+    local report_dir="${ANDROID_TEST_RESULTS_DIR}"
+    local total_tests=0
+    local skipped_tests=0
+
+    if [ ! -d "${report_dir}" ]; then
+        echo "ERROR: Android test report directory was not generated: ${report_dir}"
+        exit 1
+    fi
+
+    # shellcheck disable=SC2012
+    local report_files
+    report_files=$(ls "${report_dir}"/*.xml 2>/dev/null || true)
+    if [ -z "${report_files}" ]; then
+        echo "ERROR: Android test reports were not generated in ${report_dir}"
+        exit 1
+    fi
+
+    while IFS= read -r xml; do
+        local tests
+        local skipped
+        tests=$(grep -oE 'tests="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
+        skipped=$(grep -oE 'skipped="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
+        total_tests=$((total_tests + tests))
+        skipped_tests=$((skipped_tests + skipped))
+    done <<< "${report_files}"
+
+    if [ "${total_tests}" -eq 0 ] || [ "${total_tests}" -eq "${skipped_tests}" ]; then
+        echo "ERROR: Android instrumentation tests were not executed successfully (total=${total_tests}, skipped=${skipped_tests})."
+        exit 1
+    fi
 }
 
 # Parse parameters of this script
@@ -61,6 +95,7 @@ if [ "${TYPE}" == "unit" ] ; then
     ./gradlew :library:testDebugUnitTest
 elif [ "${TYPE}" == "android" ] ; then
     ./gradlew :library:connectedDebugAndroidTest
+    verify_android_instrumentation_results
 else
     echo "Invalid -type value '${TYPE}'. Expected 'unit' or 'android'."
     print_usage

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,7 @@ ANDROID_TEST_RESULTS_DIR="library/build/outputs/androidTest-results/connected"
 
 TYPE=""
 CONFIG_JSON=""
+CONFIG_FILE_PATH="library/src/androidTest/assets/config.json"
 
 print_usage() {
     echo "Usage: sh scripts/test.sh -type <unit|android> [-config '<json>']"
@@ -16,52 +17,54 @@ print_usage() {
     echo "  -type     unit    Runs JVM unit tests (:library:testDebugUnitTest)"
     echo "            android Runs Android instrumentation tests (:library:connectedDebugAndroidTest)"
     echo "  -config   Optional JSON content that will be written to"
-    echo "            library/src/androidTest/assets/config.json"
+    echo "            ${CONFIG_FILE_PATH}"
 }
 
-verify_android_instrumentation_results() {
-    local report_dir="${ANDROID_TEST_RESULTS_DIR}"
-    local total_tests=0
-    local skipped_tests=0
+die() {
+    echo "ERROR: $1"
+    exit 1
+}
 
-    if [ ! -d "${report_dir}" ]; then
-        echo "ERROR: Android test report directory was not generated: ${report_dir}"
-        exit 1
-    fi
-
-    local report_files=()
-    while IFS= read -r xml; do
-        report_files+=("${xml}")
-    done < <(find "${report_dir}" -type f -name "*.xml" | sort)
-
-    if [ "${#report_files[@]}" -eq 0 ]; then
-        echo "ERROR: Android test reports were not generated in ${report_dir}"
-        exit 1
-    fi
-
-    for xml in "${report_files[@]}"; do
-        local tests
-        local skipped
-
-        tests=$(grep -c '<testcase ' "${xml}" || echo "0")
-        skipped=$(grep -c '<skipped' "${xml}" || echo "0")
-
-        if [ "${tests}" -eq 0 ]; then
-            tests=$(grep -oE 'tests="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
-        fi
-        if [ "${skipped}" -eq 0 ]; then
-            skipped=$(grep -oE 'skipped="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
-        fi
-
-        total_tests=$((total_tests + tests))
-        skipped_tests=$((skipped_tests + skipped))
+parse_arguments() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -type)
+                [ $# -ge 2 ] || die "Missing value for -type."
+                TYPE="$2"
+                shift 2
+                ;;
+            -config)
+                [ $# -ge 2 ] || die "Missing value for -config."
+                CONFIG_JSON="$2"
+                shift 2
+                ;;
+            -h|--help)
+                print_usage
+                exit 0
+                ;;
+            *)
+                die "Unknown parameter ${1}"
+                ;;
+        esac
     done
+}
 
-    echo "Android instrumentation results: total=${total_tests}, skipped=${skipped_tests}, reportFiles=${#report_files[@]}"
+validate_arguments() {
+    if [ -z "${TYPE}" ]; then
+        print_usage
+        die "Missing required parameter: -type"
+    fi
 
-    if [ "${total_tests}" -eq 0 ] || [ "${total_tests}" -eq "${skipped_tests}" ]; then
-        echo "ERROR: Android instrumentation tests were not executed successfully (total=${total_tests}, skipped=${skipped_tests})."
-        exit 1
+    if [ "${TYPE}" != "unit" ] && [ "${TYPE}" != "android" ]; then
+        print_usage
+        die "Invalid -type value '${TYPE}'. Expected 'unit' or 'android'."
+    fi
+}
+
+write_android_test_config_if_provided() {
+    if [ -n "${CONFIG_JSON}" ]; then
+        printf '%s' "${CONFIG_JSON}" > "${CONFIG_FILE_PATH}"
+        echo "Config written to ${CONFIG_FILE_PATH}"
     fi
 }
 
@@ -70,10 +73,9 @@ select_running_emulator_serial() {
     serials=$(adb devices | awk '/^emulator-[0-9]+[[:space:]]+device$/ { print $1 }')
 
     if [ -z "${serials}" ]; then
-        echo "ERROR: No running Android emulator in 'device' state found via adb."
         echo "adb devices output:"
         adb devices
-        exit 1
+        die "No running Android emulator in 'device' state found via adb."
     fi
 
     local selected
@@ -84,55 +86,93 @@ select_running_emulator_serial() {
     export ANDROID_SERIAL="${selected}"
 }
 
-# Parse parameters of this script
-while [[ $# -gt 0 ]]
-do
-    case "$1" in
-        -type)
-            TYPE="$2"
-            shift
-            shift
-            ;;
-        -config)
-            CONFIG_JSON="$2"
-            shift
-            shift
-            ;;
-        -h|--help)
-            print_usage
-            exit 0
-            ;;
-        *)
-            echo "Unknown parameter ${1}"
-            print_usage
-            exit 1
-            ;;
-    esac
-done
+collect_android_report_files() {
+    local report_dir="$1"
+    # AGP/Gradle can place connected-test XML reports in variant/device subfolders.
+    # Return a recursive, stable list so CI parsing is not tied to one exact layout.
+    find "${report_dir}" -type f -name "*.xml" | sort
+}
 
-if [ -z "${TYPE}" ]; then
-    echo "Missing required parameter: -type"
-    print_usage
-    exit 1
-fi
+count_report_testcases() {
+    local xml="$1"
+    local tests
+    tests=$(grep -c '<testcase ' "${xml}" || true)
+    if [ "${tests}" -eq 0 ]; then
+        # Fallback for older/minimal XML formats that expose only suite attributes.
+        tests=$(grep -oE 'tests="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
+    fi
+    echo "${tests}"
+}
 
-pushd "${SCRIPT_FOLDER}/.."
+count_report_skipped() {
+    local xml="$1"
+    local skipped
+    skipped=$(grep -c '<skipped' "${xml}" || true)
+    if [ "${skipped}" -eq 0 ]; then
+        skipped=$(grep -oE 'skipped="[0-9]+"' "${xml}" | head -n 1 | grep -oE '[0-9]+' || echo "0")
+    fi
+    echo "${skipped}"
+}
 
-if [ -n "${CONFIG_JSON}" ]; then
-    printf '%s' "${CONFIG_JSON}" > "library/src/androidTest/assets/config.json"
-    echo "Config written to library/src/androidTest/assets/config.json"
-fi
+verify_android_instrumentation_results() {
+    local report_dir="${ANDROID_TEST_RESULTS_DIR}"
+    local total_tests=0
+    local skipped_tests=0
+    local report_files_count=0
 
-if [ "${TYPE}" == "unit" ] ; then
+    if [ ! -d "${report_dir}" ]; then
+        die "Android test report directory was not generated: ${report_dir}"
+    fi
+
+    while IFS= read -r xml; do
+        local tests
+        local skipped
+
+        tests=$(count_report_testcases "${xml}")
+        skipped=$(count_report_skipped "${xml}")
+
+        total_tests=$((total_tests + tests))
+        skipped_tests=$((skipped_tests + skipped))
+        report_files_count=$((report_files_count + 1))
+    done < <(collect_android_report_files "${report_dir}")
+
+    if [ "${report_files_count}" -eq 0 ]; then
+        die "Android test reports were not generated in ${report_dir}"
+    fi
+
+    # CI guard: fail if no tests ran or if every discovered test case was skipped.
+    echo "Android instrumentation results: total=${total_tests}, skipped=${skipped_tests}, reportFiles=${report_files_count}"
+    if [ "${total_tests}" -eq 0 ] || [ "${total_tests}" -eq "${skipped_tests}" ]; then
+        die "Android instrumentation tests were not executed successfully (total=${total_tests}, skipped=${skipped_tests})."
+    fi
+}
+
+run_unit_tests() {
     ./gradlew :library:testDebugUnitTest
-elif [ "${TYPE}" == "android" ] ; then
+}
+
+run_android_tests() {
     select_running_emulator_serial
     ./gradlew :library:connectedDebugAndroidTest
     verify_android_instrumentation_results
-else
-    echo "Invalid -type value '${TYPE}'. Expected 'unit' or 'android'."
-    print_usage
-    exit 1
-fi
+}
 
-popd
+run_tests() {
+    if [ "${TYPE}" == "unit" ]; then
+        run_unit_tests
+    else
+        run_android_tests
+    fi
+}
+
+main() {
+    parse_arguments "$@"
+    validate_arguments
+
+    pushd "${SCRIPT_FOLDER}/.." >/dev/null
+    write_android_test_config_if_provided
+    run_tests
+    popd >/dev/null
+}
+
+main "$@"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,10 @@ dependencyResolutionManagement {
         google()
         mavenLocal()
         mavenCentral()
+        maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            content { includeGroup("com.wultra.android.powerauth") }
+        }
     }
 }
 include(":library")


### PR DESCRIPTION
- Add validation for -type and -config parameters to ensure they have values
- Add trap to guarantee popd is called on script exit, even on error
- Improves robustness for both local development and CI/CD pipelines