### PR TITLE
Fix test.sh cleanup on failure

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -169,10 +169,12 @@ main() {
     parse_arguments "$@"
     validate_arguments
 
+    trap 'popd >/dev/null' EXIT
     pushd "${SCRIPT_FOLDER}/.." >/dev/null
     write_android_test_config_if_provided
     run_tests
     popd >/dev/null
+    trap - EXIT
 }
 
 main "$@"


### PR DESCRIPTION
The test script should fail gracefully when setup or test execution fails, without leaving the shell in a changed directory state.

This update hardens `scripts/test.sh` by ensuring directory cleanup is always executed: `main()` now installs an `EXIT` trap right before `pushd`, so `popd` runs even when a command fails between `pushd` and normal completion. The trap is cleared after successful manual `popd` to avoid duplicate execution.

This keeps error behavior predictable and prevents side effects in CI and local runs when `set -e` aborts execution early.